### PR TITLE
Allow for "both" chambers

### DIFF
--- a/R/recent_bills_by_type.R
+++ b/R/recent_bills_by_type.R
@@ -15,10 +15,10 @@
 #' \donttest{
 #' recent_bills_by_type(115, 'house', 'introduced')
 #' }
-recent_bills_by_type <- function(congress, chamber = c('house', 'senate'), type = c('introduced', 'updated', 'active', 'passed', 'enacted', 'vetoed'), myAPI_Key){
+recent_bills_by_type <- function(congress, chamber = c('house', 'senate', 'both'), type = c('introduced', 'updated', 'active', 'passed', 'enacted', 'vetoed'), myAPI_Key){
   API = 'congress'
-  if(!chamber%in%c('house','senate'))
-    stop("Incorrect Chamber. Should be \'house\' or \'senate\', lowercase.")
+  if(!chamber%in%c('house','senate','both'))
+    stop("Incorrect Chamber. Should be \'house\', \'senate\', or \'both\', lowercase.")
   if(!type%in%c('introduced', 'updated', 'active', 'passed', 'enacted', 'vetoed'))
     stop("Incorrect Chamber. Should be \'introduced\', \'updated\', \'active\', \'passed\', \'enacted\', \'vetoed\', lowercase.")
   if(!congress%in% 105:115)


### PR DESCRIPTION
The API endpoint for getting recent bills by type allows a "both" chambers option. As far as I can tell it's the only endpoint that allows this. Documentation at https://projects.propublica.org/api-docs/congress-api/bills/#get-recent-bills. Fixes issue #5 